### PR TITLE
add output message in output tab

### DIFF
--- a/R/mod_PopStrApp.R
+++ b/R/mod_PopStrApp.R
@@ -493,9 +493,15 @@ mod_PopStrApp_server <- function(id, data){
         if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
         data(result) # update data with results
         cat(paste("Population structure analysis with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"was saved."))
+        output$outPopStr2 <- renderPrint({
+          cat(paste("Population structure analysis with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"was saved."))
+        })
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
       }else{
         cat(paste("Analysis failed with the following error message: \n\n",uno[[1]]))
+        output$outPopStr2 <- renderPrint({
+          cat(paste("Analysis failed with the following error message: \n\n",uno[[1]]))
+        })
       }
 
       shinybusy::remove_modal_spinner()

--- a/R/mod_abiDashboard.R
+++ b/R/mod_abiDashboard.R
@@ -76,6 +76,8 @@ mod_abiDashboard_ui <- function(id){
                                     tabsetPanel(
                                       tabPanel("Dashboard", icon = icon("file-image"),
                                                br(),
+                                               textOutput(ns("outAbi2")),
+                                               br(),
                                                downloadButton(ns("downloadReportAbi"), "Download dashboard"),
                                                br(),
                                                uiOutput(ns('reportAbi'))
@@ -156,7 +158,13 @@ mod_abiDashboard_server <- function(id, data){
       if(!is.null(dtAbi)){
         dtAbi <- dtAbi[which(dtAbi$module %in% c("ocs")),]
         traitsAbi <- unique(dtAbi$analysisId)
-        if(length(traitsAbi) > 0){names(traitsAbi) <- as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT")}
+        if(length(traitsAbi) > 0){
+          if("analysisIdName" %in% colnames(dtAbi)){
+            names(traitsAbi) <- paste(dtAbi$analysisIdName, as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT"), sep = "_")
+          }else{
+            names(traitsAbi) <- as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT")
+          }
+        }
         updateSelectInput(session, "versionSelection", choices = traitsAbi)
       }
     })
@@ -167,7 +175,13 @@ mod_abiDashboard_server <- function(id, data){
       if(!is.null(dtAbi)){
         dtAbi <- dtAbi[which(dtAbi$module %in% c("rgg")),]
         traitsAbi <- unique(dtAbi$analysisId)
-        if(length(traitsAbi) > 0){names(traitsAbi) <- as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT")}
+        if(length(traitsAbi) > 0){
+          if("analysisIdName" %in% colnames(dtAbi)){
+            names(traitsAbi) <- paste(dtAbi$analysisIdName, as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT"), sep = "_")
+          }else{
+            names(traitsAbi) <- as.POSIXct(traitsAbi, origin="1970-01-01", tz="GMT")
+          }
+        }
         updateSelectInput(session, "versionHistory", choices = traitsAbi)
       }
     })
@@ -240,9 +254,15 @@ mod_abiDashboard_server <- function(id, data){
       if(!inherits(result,"try-error")) {
         data(result) # update data with results
         cat("Data ready for dashboard. Please go to the report tab.")
+        output$outAbi2 <- renderPrint({
+          cat("Data ready for dashboard. Please go to the report tab.")
+        })
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
       }else{
         cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        output$outAbi2 <- renderPrint({
+          cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        })
       }
       ##
 

--- a/R/mod_dataConsistApp.R
+++ b/R/mod_dataConsistApp.R
@@ -116,6 +116,8 @@ mod_dataConsistApp_ui <- function(id){
                                 tabsetPanel(
                                   tabPanel("Dashboard", icon = icon("file-image"),
                                            br(),
+                                           textOutput(ns("outConsist2")),
+                                           br(),
                                            downloadButton(ns("downloadReportQaPheno"), "Download dashboard"),
                                            br(),
                                            uiOutput(ns('reportQaPheno')),
@@ -308,10 +310,16 @@ mod_dataConsistApp_server <- function(id, data){
           data(result)
           # cat(crayon::green(paste("QA step with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT"),"for trait",paste(input$traitOutqPhenoMultiple, collapse = ", "),"saved. Now you can proceed to perform Single Trial Analysis.")))
           cat(paste("QA step with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT"),"saved. Now you can move to another module."))
+          output$outConsist2 <- renderPrint({
+            cat(paste("QA step with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT"),"saved. Now you can move to another module."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
           shinybusy::remove_modal_spinner()
         }else{
           shinybusy::remove_modal_spinner()
+          output$outConsist2 <- renderPrint({
+            cat("Consistency rules for selected crop not available yet")
+          })
           stop("Consistency rules for selected crop not available yet", call. = FALSE)
         }
 
@@ -363,6 +371,9 @@ mod_dataConsistApp_server <- function(id, data){
         hideAll$clearAll <- FALSE
       }else{
         cat("Please meet the data conditions before you identify and save outliers.")
+        output$outConsist2 <- renderPrint({
+          cat("Please meet the data conditions before you identify and save outliers.")
+        })
       }
     })
 

--- a/R/mod_expDesignEditApp.R
+++ b/R/mod_expDesignEditApp.R
@@ -77,15 +77,16 @@ mod_expDesignEditApp_ui <- function(id){
                                                   column(width=3,
                                                          br(),
                                                          actionButton(ns("runFieldClean"), "Tag factors", icon = icon("play-circle")),
-                                                         textOutput(ns("outExp"))
                                                   ),
-                                           ),
+                                           ),textOutput(ns("outExp"))
                                   ),
                                 ) # end of tabset
                        ),# end of input panel
                        tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                 tabsetPanel(
                                   tabPanel("Dashboard", icon = icon("file-image"),
+                                           br(),
+                                           textOutput(ns("outExp2")),
                                            br(),
                                            downloadButton(ns("downloadReportQaPheno"), "Download dashboard"),
                                            br(),
@@ -284,6 +285,9 @@ mod_expDesignEditApp_server <- function(id, data){
         available <- setdiff(available,"")
         if( length(available) == 0 ){
           cat( "Please map some of your experimental design columns using the 'Data Retrieval' tab in the 'Phenotype' section to use this module.")
+          output$outExp2 <- renderPrint({
+            cat( "Please map some of your experimental design columns using the 'Data Retrieval' tab in the 'Phenotype' section to use this module.")
+          })
         }else{
           object <- data()
           result <- cgiarPipeline::modifExpDesign(object, df=xx$df)
@@ -292,6 +296,9 @@ mod_expDesignEditApp_server <- function(id, data){
           if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
           data(result)
           cat(paste("QA step with id:",as.POSIXct( aid, origin="1970-01-01", tz="GMT"),"saved."))
+          output$outExp2 <- renderPrint({
+            cat(paste("QA step with id:",as.POSIXct( aid, origin="1970-01-01", tz="GMT"),"saved."))
+          })
         }
         shinybusy::remove_modal_spinner()
 

--- a/R/mod_filterPhenoApp.R
+++ b/R/mod_filterPhenoApp.R
@@ -86,15 +86,16 @@ mod_filterPhenoApp_ui <- function(id){
                                                   column(width=3,
                                                          br(),
                                                          actionButton(ns("runFilterRaw"), "Filter dataset", icon = icon("play-circle")),
-                                                         textOutput(ns("outFilterRaw")),
                                                   ),
-                                           ),
+                                           ),textOutput(ns("outFilterRaw")),
                                   ),
                                 ) # end of tabset
                        ),# end of input panel
                        tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                 tabsetPanel(
                                   tabPanel("Dashboard", icon = icon("file-image"),
+                                           br(),
+                                           textOutput(ns("outFilterRaw2")),
                                            br(),
                                            downloadButton(ns("downloadReportQaPheno"), "Download dashboard"),
                                            br(),
@@ -405,6 +406,9 @@ mod_filterPhenoApp_server <- function(id, data){
           outliers <- data.frame(matrix(nrow=0, ncol=6))
           colnames(outliers) <- c("module" ,"analysisId" ,"trait","reason","row" , "value" )
           cat("No traits selected to filter.")
+          output$outFilterRaw2 <- renderPrint({
+            cat("No traits selected to filter.")
+          })
         }
       }else{ # if user only wants to filter one trait
         outliers <- newOutliers()
@@ -413,11 +417,17 @@ mod_filterPhenoApp_server <- function(id, data){
       analysisId <- as.numeric(Sys.time())
       if(nrow(outliers) == 0){ # no outliers found
         cat("No data to filter.")
+        output$outFilterRaw2 <- renderPrint({
+          cat("No data to filter.")
+        })
       }else{ # we found outliers
         # outliers$analysisId <- analysisId
         outliers[,"analysisId"] <- analysisId
         outliers[,"module"] <- "qaFilter"
         cat(paste("Filtering step with id:",as.POSIXct(analysisId, origin="1970-01-01", tz="GMT"),"for trait",ifelse(input$multiTraitFilter, paste(input$traitFilterPhenoMultiple, collapse = ", "),input$traitFilterPheno),"saved."))
+        output$outFilterRaw2 <- renderPrint({
+          cat(paste("Filtering step with id:",as.POSIXct(analysisId, origin="1970-01-01", tz="GMT"),"for trait",ifelse(input$multiTraitFilter, paste(input$traitFilterPhenoMultiple, collapse = ", "),input$traitFilterPheno),"saved."))
+        })
       }
       myoutliersReduced <- unique(rbind(myoutliers, outliers))
 

--- a/R/mod_getDataPheno.R
+++ b/R/mod_getDataPheno.R
@@ -1034,12 +1034,12 @@ mod_getDataPheno_server <- function(id, map = NULL, data = NULL, res_auth=NULL){
         if(length(otherEnvironmentColumn) > 1){ # if user has mapped more than one column
           myObject$data$pheno[,myObject$metadata$pheno[environmentColumn, "value"]] <- apply(myObject$data$pheno[, myObject$metadata$pheno[otherEnvironmentColumn, "value"], drop=FALSE],1, function(x){paste(x, collapse = "_")} )
           data(myObject)
-          shinyalert::shinyalert(title = "Success!", text = paste("Columns",paste(myObject$metadata$pheno[otherEnvironmentColumn, "value"], collapse = ", "), "concatenated and pasted in the",myObject$metadata$pheno[environmentColumn, "value"], "column"), type = "success")
+          shinyalert::shinyalert(title = "Success!", text = paste0("Columns ",paste(myObject$metadata$pheno[otherEnvironmentColumn, "value"], collapse = ", "), " concatenated and pasted in the '",myObject$metadata$pheno[environmentColumn, "value"], "' column"), type = "success")
           # cat(paste("Columns",paste(myObject$metadata$pheno[otherEnvironmentColumn, "value"], collapse = ", "), "concatenated and pasted in the",myObject$metadata$pheno[environmentColumn, "value"], "column"))
         }else if(length(otherEnvironmentColumn) == 1){
           myObject$data$pheno[,myObject$metadata$pheno[environmentColumn, "value"]] <- myObject$data$pheno[, myObject$metadata$pheno[otherEnvironmentColumn, "value"]]
           data(myObject)
-          shinyalert::shinyalert(title = "Success!", text = paste0(myObject$metadata$pheno[environmentColumn, "value"], "' column is equal to ", myObject$metadata$pheno[otherEnvironmentColumn, "value"]), type = "success")
+          shinyalert::shinyalert(title = "Success!", text = paste0("'",myObject$metadata$pheno[environmentColumn, "value"], "' column is equal to ", myObject$metadata$pheno[otherEnvironmentColumn, "value"]), type = "success")
           # cat("No additional columns to concatenate to your 'study' column")
         }else {
           myObject$metadata$pheno <- myObject$metadata$pheno[-which(myObject$metadata$pheno$parameter == "environment"), ]
@@ -1059,7 +1059,7 @@ mod_getDataPheno_server <- function(id, map = NULL, data = NULL, res_auth=NULL){
           myObject$data$pheno[,"environment"] <- myObject$data$pheno[, myObject$metadata$pheno[otherEnvironmentColumn, "value"]]
           myObject$metadata$pheno <- rbind(myObject$metadata$pheno, data.frame(parameter = 'environment', value = 'environment' ))
           data(myObject)
-          shinyalert::shinyalert(title = "Success!", text = paste("No additional columns to concatenate. 'environment' column is equal to", myObject$metadata$pheno[otherEnvironmentColumn, " value"]), type = "success")
+          shinyalert::shinyalert(title = "Success!", text = paste("No additional columns to concatenate. 'environment' column is equal to", myObject$metadata$pheno[otherEnvironmentColumn, "value"]), type = "success")
         }else{
           shinyalert::shinyalert(title = "Error!", text = paste("Please map at least one of the columns 'year', 'season', 'timepoint', 'location', 'trial', 'study' or 'management' to be able to do compute the environments and perform a genetic evaluation "), type = "error")
           # cat(paste("Please map at least one of the columns 'year', 'season', 'location', 'trial' or 'study' to be able to do compute the environments and perform a genetic evaluation "))

--- a/R/mod_gwasqkApp.R
+++ b/R/mod_gwasqkApp.R
@@ -148,14 +148,15 @@ mod_gwasqkApp_ui <- function(id){
                                                               ),
                                                       ),
                                                       br(),
-                                               ),
-                                               textOutput(ns("outGwas")),
+                                               ), textOutput(ns("outGwas")),
                                       ),
                                     )
                            ),
                            tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                     tabsetPanel(
                                       tabPanel("Dashboard", icon = icon("file-image"),
+                                               br(),
+                                               textOutput(ns("outGwas2")),
                                                br(),
                                                # div(tags$p("Please download the report below:") ),
                                                downloadButton(ns("downloadReportGwas"), "Download dashboard"),
@@ -308,7 +309,13 @@ mod_gwasqkApp_server <- function(id, data){
       dtGwas <- dtGwas$status
       dtGwas <- dtGwas[which(dtGwas$module %in% c("sta","mtaLmms")),]
       traitsGwas <- unique(dtGwas$analysisId)
-      if(length(traitsGwas) > 0){names(traitsGwas) <- as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT")}
+      if(length(traitsGwas) > 0){
+        if("analysisIdName" %in% colnames(dtGwas)){
+          names(traitsGwas) <- paste(dtGwas$analysisIdName, as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT"), sep = "_")
+        }else{
+          names(traitsGwas) <- as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT")
+        }
+      }
       updateSelectInput(session, "version2Gwas", choices = traitsGwas)
     })
     # ## version qa marker
@@ -318,7 +325,13 @@ mod_gwasqkApp_server <- function(id, data){
       dtGwas <- dtGwas$status
       dtGwas <- dtGwas[which(dtGwas$module == "qaGeno"),]
       traitsGwas <- unique(dtGwas$analysisId)
-      if(length(traitsGwas) > 0){names(traitsGwas) <- as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT")}
+      if(length(traitsGwas) > 0){
+        if("analysisIdName" %in% colnames(dtGwas)){
+          names(traitsGwas) <- paste(dtGwas$analysisIdName, as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT"), sep = "_")
+        }else{
+          names(traitsGwas) <- as.POSIXct(traitsGwas, origin="1970-01-01", tz="GMT")
+        }
+      }
       updateSelectInput(session, "versionMarker2Gwas", choices = traitsGwas)
     })
     #################
@@ -615,10 +628,16 @@ mod_gwasqkApp_server <- function(id, data){
           if(!is.null(dtGwas$data$geno)){ # if user actually has marker data
             shinybusy::remove_modal_spinner()
             cat("Please run the 'Markers QA/QC' module prior to run a GWAS model.")
+            output$outGwas2 <- renderPrint({
+              cat("Please run the 'Markers QA/QC' module prior to run a GWAS model.")
+            })
             # stop("Please run the 'Markers QA/QC' module prior to run a gBLUP or rrBLUP model.", call. = FALSE)
           }else{ # if user does NOT have marker data and wanted a marker-based model
             shinybusy::remove_modal_spinner()
             cat("GWAS requires marker information. Alternatively, go back to the 'Retrieve Data' section and upload your marker data.")
+            output$outGwas2 <- renderPrint({
+              cat("GWAS requires marker information. Alternatively, go back to the 'Retrieve Data' section and upload your marker data.")
+            })
             # stop("Please pick a different model, rrBLUP, gBLUP and ssBLUP require marker information. Alternatively, go back to the 'Retrieve Data' section and upload your marker data.")
           }
         }else{ markerVersionToUse <- input$versionMarker2Gwas} # there is a versionMarker2Mta id
@@ -655,9 +674,15 @@ mod_gwasqkApp_server <- function(id, data){
         if(!inherits(result,"try-error")) {
           data(result) # update data with results
           cat(paste("Genome wide association study step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved."))
+          output$outGwas2 <- renderPrint({
+            cat(paste("Genome wide association study step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outGwas2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()

--- a/R/mod_hybridityApp.R
+++ b/R/mod_hybridityApp.R
@@ -128,14 +128,15 @@ mod_hybridityApp_ui <- function(id){
                                                                     br(),
                                                              ),
 
-                                                      ),
-                                                      textOutput(ns("outQaMb")),
+                                                      ),textOutput(ns("outQaMb")),
                                              ),
                                            ) # end of tabset
                                   ),# end of output panel
                                   tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                            tabsetPanel(
                                              tabPanel("Dashboard", icon = icon("file-image"),
+                                                      br(),
+                                                      textOutput(ns("outQaMb2")),
                                                       br(),
                                                       downloadButton(ns("downloadReportVerifGeno"), "Download dashboard"),
                                                       br(),
@@ -462,6 +463,9 @@ mod_hybridityApp_server <- function(id, data){
 
       if(!inherits(result,"try-error")) { # if all goes well in the run
         cat(paste("Genotype verification analysis saved with id:",as.POSIXct( result$status$analysisId[nrow(result$status)], origin="1970-01-01", tz="GMT") ))
+        output$outQaMb2 <- renderPrint({
+          cat(paste("Genotype verification analysis saved with id:",as.POSIXct( result$status$analysisId[nrow(result$status)], origin="1970-01-01", tz="GMT") ))
+        })
         if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
         data(result)
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")

--- a/R/mod_indexBaseApp.R
+++ b/R/mod_indexBaseApp.R
@@ -105,7 +105,6 @@ mod_indexBaseApp_ui <- function(id){
                                                               br(),
                                                               actionButton(ns("runIdxB"), "Calculate index", icon = icon("play-circle")),
                                                               uiOutput(ns("qaQcIdxBInfo")),
-                                                              textOutput(ns("outIdxB")),
                                                               br(),
                                                               # hr(style = "border-top: 3px solid #4c4c4c;"),
                                                        ),
@@ -115,9 +114,7 @@ mod_indexBaseApp_ui <- function(id){
                                                                                   selectInput(ns("verboseIndex"), label = "Print logs?", choices = list(TRUE,FALSE), selected = FALSE, multiple=FALSE)
                                                                                   ),
                                                               ),
-                                                ),
-
-
+                                                ),textOutput(ns("outIdxB")),
                                        ),
                                      )
                             ),
@@ -132,6 +129,8 @@ mod_indexBaseApp_ui <- function(id){
                                                 DT::DTOutput(ns("modelingIdxB"))
                                        ),
                                        tabPanel("Dashboard", icon = icon("file-image"),
+                                                br(),
+                                                textOutput(ns("outIdxB2")),
                                                 br(),
                                                 downloadButton(ns("downloadReportIndex"), "Download dashboard"),
                                                 br(),
@@ -319,9 +318,15 @@ mod_indexBaseApp_server <- function(id, data){
           data(result) # update data with results
           # save(result, file = "./R/outputs/resultIndex.RData")
           cat(paste("Selection index step with id:",result$status$analysisId[length(result$status$analysisId)],"saved. Please proceed to use this time stamp in the optimal cross selection."))
+          output$outIdxB2 <- renderPrint({
+            cat(paste("Selection index step with id:",result$status$analysisId[length(result$status$analysisId)],"saved. Please proceed to use this time stamp in the optimal cross selection."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outIdxB2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()

--- a/R/mod_indexDesireApp.R
+++ b/R/mod_indexDesireApp.R
@@ -1163,9 +1163,15 @@ mod_indexDesireApp_server <- function(id, data){
           if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
           data(result) # update data with results
           cat(paste("Selection index step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to select the best crosses using the OCS module using this time stamp."))
+          output$outIdxD2 <- renderPrint({
+            cat(paste("Selection index step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to select the best crosses using the OCS module using this time stamp."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outIdxD2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()

--- a/R/mod_masApp.R
+++ b/R/mod_masApp.R
@@ -154,6 +154,8 @@ mod_masApp_ui <- function(id){
                                            tabsetPanel(
                                              tabPanel("Dashboard", icon = icon("file-image"),
                                                       br(),
+                                                      textOutput(ns("outMAS2")),
+                                                      br(),
                                                       downloadButton(ns("downloadReportMASGeno"), "Download dashboard"),
                                                       br(),
                                                       uiOutput(ns('reportMASGeno'))
@@ -583,6 +585,9 @@ mod_masApp_server <- function(id, data){
 
       if(!inherits(result,"try-error")) { # if all goes well in the run
         cat(paste("Marker Assisted Selection analysis saved with id:",as.POSIXct( result$status$analysisId[nrow(result$status)], origin="1970-01-01", tz="GMT") ))
+        output$outMAS2 <- renderPrint({
+          cat(paste("Marker Assisted Selection analysis saved with id:",as.POSIXct( result$status$analysisId[nrow(result$status)], origin="1970-01-01", tz="GMT") ))
+        })
         if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
         data(result)
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
@@ -688,7 +693,12 @@ mod_masApp_server <- function(id, data){
           }
         )
 
-      }else{ cat(paste("Analysis failed with the following error message: \n\n",result[[1]])); hideAll$clearAll <- TRUE}
+      }else{
+        cat(paste("Analysis failed with the following error message: \n\n",result[[1]])); hideAll$clearAll <- TRUE
+        output$outMAS2 <- renderPrint({
+          cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        })
+      }
 
       hideAll$clearAll <- FALSE
 

--- a/R/mod_mtaASREMLApp.R
+++ b/R/mod_mtaASREMLApp.R
@@ -1145,9 +1145,15 @@ mod_mtaASREMLApp_server <- function(id, data){
           if("analysisIdName" %in% colnames(result$status) ){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
           data(result) # update data with results
           cat(paste("Multi-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to construct a selection index using this time stamp."))
+          output$outMtaAsr2 <- renderPrint({
+            cat(paste("Multi-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to construct a selection index using this time stamp."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outMtaAsr2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       #save(result,file="asrResult.RData")

--- a/R/mod_mtaLMMsolveApp.R
+++ b/R/mod_mtaLMMsolveApp.R
@@ -1203,9 +1203,15 @@ mod_mtaLMMsolveApp_server <- function(id, data){
           if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
           data(result) # update data with results
           cat(paste("Multi-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to construct a selection index using this time stamp."))
+          output$outMta2 <- renderPrint({
+            cat(paste("Multi-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to construct a selection index using this time stamp."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outMta2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
 

--- a/R/mod_ocsApp.R
+++ b/R/mod_ocsApp.R
@@ -1157,9 +1157,15 @@ mod_ocsApp_server <- function(id, data){
           if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
           data(result) # update data with results
           cat(paste("Optimal cross selection step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to print this list and do your crossing block."))
+          output$outOcs2 <- renderPrint({
+            cat(paste("Optimal cross selection step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to print this list and do your crossing block."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outOcs2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()

--- a/R/mod_oftStaApp.R
+++ b/R/mod_oftStaApp.R
@@ -165,11 +165,10 @@ that perform well under farmers’ conditions before these are announced to the 
                                                       column(width=3,
                                                              br(),
                                                              actionButton(ns("runOft"), "Build dashboard", icon = icon("play-circle")),
-                                                             uiOutput(ns("outOft")),
                                                              br(),
                                                       ),
 
-                                               ),
+                                               ),uiOutput(ns("outOft")),
                                       ),
                                     )
                            ),
@@ -177,7 +176,9 @@ that perform well under farmers’ conditions before these are announced to the 
                                     tabsetPanel(
                                       tabPanel("Dashboard", icon = icon("file-image"),
                                                br(),
-                                               div(tags$p("Please download the dashboard below:") ),
+                                               uiOutput(ns("outOft2")),
+                                               br(),
+                                               # div(tags$p("Please download the dashboard below:") ),
                                                downloadButton(ns("downloadReportOft"), "Download dashboard"),
                                                br(),
                                                uiOutput(ns('reportOft'))
@@ -671,6 +672,9 @@ mod_oftStaApp_server <- function(id, data){
 
         if(!inherits(result,"try-error")) {
           cat(paste("Dashboard Generated Successfully with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved."))
+          output$outOft2 <- renderPrint({
+            cat(paste("Dashboard Generated Successfully with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved."))
+          })
           shinybusy::remove_modal_spinner()
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }

--- a/R/mod_pggApp.R
+++ b/R/mod_pggApp.R
@@ -430,9 +430,15 @@ mod_pggApp_server <- function(id, data){
           data(result) # update data with results
           # save(result, file = "./R/outputs/resultPgg.RData")
           cat(paste("Predicted genetic gain step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT") ,"saved."))
+          output$outPgg2 <- renderPrint({
+            cat(paste("Predicted genetic gain step with id:",as.POSIXct( result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT") ,"saved."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outPgg2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()
@@ -526,7 +532,7 @@ mod_pggApp_server <- function(id, data){
 
     }) ## end eventReactive
 
-    output$outPgg <- output$outPgg2 <- renderPrint({
+    output$outPgg <- renderPrint({
       outPgg()
     })
 

--- a/R/mod_qaGenoApp.R
+++ b/R/mod_qaGenoApp.R
@@ -112,6 +112,8 @@ mod_qaGenoApp_ui <- function(id){
                                            tabsetPanel(
                                              tabPanel("Dashboard", icon = icon("file-image"),
                                                       br(),
+                                                      textOutput(ns("outQaMb2")),
+                                                      br(),
                                                       downloadButton(ns("downloadReportQaGeno"), "Download dashboard"),
                                                       br(),
                                                       uiOutput(ns('reportQaGeno'))
@@ -346,9 +348,15 @@ mod_qaGenoApp_server <- function(id, data){
         # if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
         data(result)
         cat(paste("Modifications to genotype information saved with id:",as.POSIXct( mods$analysisId[nrow(mods)], origin="1970-01-01", tz="GMT") ))
+        output$outQaMb2 <- renderPrint({
+          cat(paste("Modifications to genotype information saved with id:",as.POSIXct( mods$analysisId[nrow(mods)], origin="1970-01-01", tz="GMT") ))
+        })
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
       }else{
         cat("No modifications to add.")
+        output$outQaMb2 <- renderPrint({
+          cat("No modifications to add.")
+        })
       }
       shinybusy::remove_modal_spinner()
 

--- a/R/mod_qaPhenoApp.R
+++ b/R/mod_qaPhenoApp.R
@@ -452,7 +452,7 @@ mod_qaPhenoApp_server <- function(id, data){
 
     # output$value <- renderPrint({ input$outlierCoefOutqPheno })
 
-    outQaRaw <- outQaRaw2 <- eventReactive(input$runQaRaw, {
+    outQaRaw <- eventReactive(input$runQaRaw, {
       req(data())
       req(input$traitOutqPhenoMultiple)
       # req(input$outlierCoefOutqPheno)
@@ -559,11 +559,18 @@ mod_qaPhenoApp_server <- function(id, data){
             }
           )
 
+          output$outQaRaw2 <- renderPrint({
+            cat(paste("QA step with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT"),"for trait",paste(input$traitOutqPhenoMultiple, collapse = ", "),"saved. Now you can proceed to perform Single Trial Analysis."))
+          })
+
         }else{ hideAll$clearAll <- TRUE}
 
         hideAll$clearAll <- FALSE
       }else{
         cat("Please meet the data conditions before you identify and save outliers.")
+        output$outQaRaw2 <- renderPrint({
+          cat("Please meet the data conditions before you identify and save outliers.")
+        })
       }
     })
 

--- a/R/mod_qaStaApp.R
+++ b/R/mod_qaStaApp.R
@@ -82,10 +82,9 @@ mod_qaStaApp_ui <- function(id){
                                                   column(width=3,
                                                          br(),
                                                          actionButton(ns("runQaMb"), "Tag outliers", icon = icon("play-circle")),
-                                                         textOutput(ns("outQaMb")),
                                                          br(),
                                                   )
-                                           ),
+                                           ),textOutput(ns("outQaMb")),
 
                                   ),
                                 ) # end of tabset
@@ -93,6 +92,7 @@ mod_qaStaApp_ui <- function(id){
                        tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                 tabsetPanel(
                                   tabPanel("Dashboard", icon = icon("file-image"),
+                                           br(),
                                            textOutput(ns("outQaMb2")),
                                            br(),
                                            downloadButton(ns("downloadReportQaPheno"), "Download dashboard"),
@@ -293,7 +293,15 @@ mod_qaStaApp_server <- function(id, data){
             if("analysisIdName" %in% colnames(result$status)){result$status$analysisIdName[nrow(result$status)] <- input$analysisIdName}
             data(result)
             cat(paste("Modifications to phenotype information saved with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT")))
-          }else{cat("No modifications to add")}
+            output$outQaMb2 <- renderPrint({
+              cat(paste("Modifications to phenotype information saved with id:",as.POSIXct( analysisId, origin="1970-01-01", tz="GMT")))
+            })
+          }else{
+            cat("No modifications to add")
+            output$outQaMb2 <- renderPrint({
+              cat("No modifications to add")
+            })
+          }
         }
 
         shinybusy::remove_modal_spinner()
@@ -347,7 +355,7 @@ mod_qaStaApp_server <- function(id, data){
 
       }
     })
-    output$outQaMb <- output$outQaMb2 <- renderPrint({
+    output$outQaMb <- renderPrint({
       outQaMb()
     })
 

--- a/R/mod_reportBuilder.R
+++ b/R/mod_reportBuilder.R
@@ -67,9 +67,8 @@ mod_reportBuilder_ui <- function(id){
                                                column(width=12,style = "background-color:grey; color: #FFFFFF",
                                                       br(),
                                                       actionButton(ns("runReport"), "Build dashboard", icon = icon("play-circle")),
-                                                      textOutput(ns("outReport")),
                                                       br(),
-                                               ),
+                                               ),textOutput(ns("outReport")),
 
                                       ),
                                     )
@@ -77,6 +76,8 @@ mod_reportBuilder_ui <- function(id){
                            tabPanel(div(icon("arrow-right-from-bracket"), "Output tabs" ) , value = "outputTabs",
                                     tabsetPanel(
                                       tabPanel("Dashboard", icon = icon("file-image"),
+                                               br(),
+                                               textOutput(ns("outReport2")),
                                                br(),
                                                downloadButton(ns("downloadReportReport"), "Download dashboard"),
                                                br(),
@@ -146,7 +147,13 @@ mod_reportBuilder_server <- function(id, data){
         status <- data()$status
         status <- status[status$module == input$module, ]
         traitsBuilder <- status$analysisId
-        if(length(traitsBuilder) > 0){names(traitsBuilder) <- as.POSIXct(traitsBuilder, origin="1970-01-01", tz="GMT")}
+        if(length(traitsBuilder) > 0){
+          if("analysisIdName" %in% colnames(status)){
+            names(traitsBuilder) <- paste(status$analysisIdName, as.POSIXct(traitsBuilder, origin="1970-01-01", tz="GMT"), sep = "_")
+          }else{
+            names(traitsBuilder) <- as.POSIXct(traitsBuilder, origin="1970-01-01", tz="GMT")
+          }
+        }
         updateSelectInput(session, "timestamp", choices =traitsBuilder  )
       }
     })
@@ -270,9 +277,15 @@ mod_reportBuilder_server <- function(id, data){
       if(!inherits(result,"try-error")) {
         data(result) # update data with results
         cat("Report ready. Please go to the report tab.")
+        output$outReport2 <- renderPrint({
+          cat("Report ready. Please go to the report tab.")
+        })
         updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
       }else{
         cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        output$outReport2 <- renderPrint({
+          cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        })
       }
       ##
       shinybusy::remove_modal_spinner()

--- a/R/mod_staApp.R
+++ b/R/mod_staApp.R
@@ -1345,9 +1345,15 @@ mod_staApp_server <- function(id,data){
           data(result) # update data with results
           # save(result, file = "./R/outputs/resultSta.RData")
           cat(paste("Single-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to perform your multi-trial analysis using this time stamp."))
+          output$outSta2 <- renderPrint({
+            cat(paste("Single-trial analysis step with id:",as.POSIXct(result$status$analysisId[length(result$status$analysisId)], origin="1970-01-01", tz="GMT"),"saved. Please proceed to perform your multi-trial analysis using this time stamp."))
+          })
           updateTabsetPanel(session, "tabsMain", selected = "outputTabs")
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outSta2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
       shinybusy::remove_modal_spinner()
@@ -1465,7 +1471,7 @@ mod_staApp_server <- function(id,data){
 
     }) ## end eventReactive
 
-    output$outSta <- output$outSta2 <- renderPrint({
+    output$outSta <- renderPrint({
       outSta()
     })
 

--- a/R/mod_traitTransformApp.R
+++ b/R/mod_traitTransformApp.R
@@ -53,6 +53,8 @@ mod_traitTransformApp_ui <- function(id){
                                   ),
                                   tabPanel(div(icon("arrow-right-from-bracket"), "Output") ,value = "tabConOutput" ,
                                            br(),
+                                           textOutput(ns("outTraC2")),
+                                           br(),
                                            shinydashboard::box(status="success",width = 12, #background = "green", solidHeader = TRUE,
                                                                DT::DTOutput(ns("rawPheno")),
                                            ),
@@ -70,6 +72,8 @@ mod_traitTransformApp_ui <- function(id){
                                            # hr(style = "border-top: 1px solid #4c4c4c;"),
                                   ),
                                   tabPanel(div(icon("arrow-right-from-bracket"), "Output") ,value = "tabEqualOutput" ,
+                                           br(),
+                                           textOutput(ns("outEqual2")),
                                            br(),
                                            DT::DTOutput(ns("rawPheno2")),
                                   ),
@@ -99,6 +103,8 @@ mod_traitTransformApp_ui <- function(id){
                                            textOutput(ns("outBal")),
                                   ),
                                   tabPanel(div(icon("arrow-right-from-bracket"), "Output") ,value = "tabFreeOutput" ,
+                                           br(),
+                                           textOutput(ns("outBal2")),
                                            br(),
                                            DT::DTOutput(ns("rawPheno3")),
                                   ),
@@ -199,8 +205,14 @@ mod_traitTransformApp_server <- function(id, data){
           observe({paramsNew$vars <- intersect(colnames(result$data$pheno), paste(selTrait, selTrans, sep="_"))})
           updateTabsetPanel(session, "tabConversion", selected = "tabConOutput")
           cat(paste("Additional traits added to the phenotypic dataset."))
+          output$outTraC2 <- renderPrint({
+            cat(paste("Additional traits added to the phenotypic dataset."))
+          })
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outTraC2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }
     })
@@ -256,12 +268,21 @@ mod_traitTransformApp_server <- function(id, data){
           observe({paramsNew$vars <- input$newName})
           updateTabsetPanel(session, "tabEqualizing", selected = "tabEqualOutput")
           cat(paste("Traits", paste(input$traitEqualPheno, collapse = ", "),"equalized. New trait created in the phenotypic dataset."))
+          output$outEqual2 <- renderPrint({
+            cat(paste("Traits", paste(input$traitEqualPheno, collapse = ", "),"equalized. New trait created in the phenotypic dataset."))
+          })
           # observe({input$newName <- NULL})
         }else{
           cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          output$outEqual2 <- renderPrint({
+            cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+          })
         }
       }else{
-        print("You need to provide more than one trait")
+        cat("You need to provide more than one trait")
+        output$outEqual2 <- renderPrint({
+          cat("You need to provide more than one trait")
+        })
       }
     })
     output$outEqual <- renderPrint({
@@ -301,9 +322,15 @@ mod_traitTransformApp_server <- function(id, data){
         updateTabsetPanel(session, "tabFree", selected = "tabFreeOutput")
         print(paste("New variable", input$newNameCalc, "added to the dataset."))
         cat(paste("Trait", input$newNameCalc, "computed. New trait created in the phenotypic dataset."))
+        output$outBal2 <- renderPrint({
+          cat(paste("Trait", input$newNameCalc, "computed. New trait created in the phenotypic dataset."))
+        })
         # observe({input$newNameCalc <- NULL})
       }else{
         cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        output$outBal2 <- renderPrint({
+          cat(paste("Analysis failed with the following error message: \n\n",result[[1]]))
+        })
       }
 
     })

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -87,6 +87,8 @@
 #
 # usethis::use_package( "shinymanager" )
 #
+# usethis::use_package("ggcorrplot")
+#
 # # added for OFT report
 # usethis::use_package("janitor")
 # usethis::use_package("htmltools")

--- a/inst/rmd/reportMtaLMMsolver.Rmd
+++ b/inst/rmd/reportMtaLMMsolver.Rmd
@@ -1468,9 +1468,9 @@ if (is.null(result)){
         cat("\n\n#####", iTrait4, "{.tabset .tabset-pills}       \n\n")
         if(!(iType4 %in% c("environment_designation", "designation_environment",
                            "environment:designation", "designation:environment"))){
-          envirTypes2 <- setdiff(envirTypes,c("(Intercept)"))
-        } else{
           envirTypes2 <- c("(Intercept)")
+        } else{
+          envirTypes2 <- setdiff(envirTypes,c("(Intercept)"))
         }
         for(iEnv4 in envirTypes2){
           cat("\n\n######", iEnv4, "{.tabset .tabset-pills}       \n\n")


### PR DESCRIPTION
Changes made:
- added output message in the output tab
- for some modules, only the analysisId is shown in the list of options, it was modified to make it similar to other modules which shows <analysisIdName>_<analysisId>
- added missing package used in one of the modules: ggcorrplot
- improved shiny alert messages for getDataPheno module
- updated filtering of choices in mta report: merit estimate of top entries